### PR TITLE
Fix error handling logic when can't find .tmux-sessionizer on current directory

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -245,6 +245,9 @@ func (sh *SessionHandler) buildParentDirSet() (map[string]struct{}, error) {
 		}
 		file, err := os.Open(path)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
 			return nil, fmt.Errorf("failed to open config file: %w", err)
 		}
 		defer file.Close()


### PR DESCRIPTION
SSIA

This is not tested with some integration or unit tests

